### PR TITLE
Fixes gh-23: Removes worker termination when the clock stops.

### DIFF
--- a/examples/workersetinterval-clock/index.html
+++ b/examples/workersetinterval-clock/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+        <title>WorkerSetInterval Clock Example</title>
+
+        <script type="text/javascript" src="../../node_modules/infusion/dist/infusion-framework.js"></script>
+        <script type="text/javascript" src="../../dist/bergson-only.js"></script>
+        <script type="text/javascript" src="workersetinterval-example.js"></script>
+
+    </head>
+
+    <body>
+        <div id="worker-example">
+            <div><button>Count to 10</button></div>
+            <br />
+            <div>Tick count: <span class="tickCounter"></span></div>
+        </div>
+        <script>
+            berg.examples.workerSetIntervalClock("#worker-example");
+        </script>
+    </body>
+</html>

--- a/examples/workersetinterval-clock/workersetinterval-example.js
+++ b/examples/workersetinterval-clock/workersetinterval-example.js
@@ -1,0 +1,71 @@
+fluid.defaults("berg.examples.workerSetIntervalClock", {
+    gradeNames: "fluid.viewComponent",
+
+    model: {
+        tickCount: 0
+    },
+
+    components: {
+        clock: {
+            type: "berg.clock.workerSetInterval",
+            options: {
+                freq: 1
+            }
+        }
+    },
+    modelListeners: {
+        tickCount: {
+            "this": "{that}.dom.tickCounter",
+            method: "text",
+            args: ["{change}.value"]
+        }
+    },
+
+    events: {
+        onButtonClick: null,
+        onTick: "{clock}.events.onTick"
+    },
+
+    listeners: {
+        "onCreate.bindButtonClick": {
+            "this": "{that}.dom.button",
+            method: "click",
+            args: ["{that}.events.onButtonClick.fire"]
+        },
+
+        "onButtonClick.resetCounter": {
+            changePath: "tickCount",
+            value: 0
+        },
+
+        "onButtonClick.stopClock": "{clock}.stop()",
+
+        "onButtonClick.startClock": "{clock}.start()",
+
+        "onTick.count": {
+            funcName: "berg.examples.workerSetIntervalClock.countTick",
+            args: ["{that}"]
+        },
+
+        "onTick.stopAfterTen": {
+            priority: "after:count",
+            funcName: "berg.examples.workerSetIntervalClock.stopAfterTen",
+            args: ["{that}"]
+        }
+    },
+
+    selectors: {
+        tickCounter: ".tickCounter",
+        button: "button"
+    }
+});
+
+berg.examples.workerSetIntervalClock.countTick = function (that) {
+    that.applier.change("tickCount", that.model.tickCount + 1);
+};
+
+berg.examples.workerSetIntervalClock.stopAfterTen = function (that) {
+    if (that.model.tickCount === 10) {
+        that.clock.stop();
+    }
+};

--- a/src/js/worker-scheduler.js
+++ b/src/js/worker-scheduler.js
@@ -92,19 +92,21 @@ var fluid = fluid || require("infusion"),
         },
 
         listeners: {
-            onCreate: [
-                {
-                    func: "{that}.postMessage",
-                    args: ["create", ["berg.scheduler.postMessage", "{that}.options.remoteSchedulerOptions"]]
-                }
-            ],
+            "onCreate.postSchedulerOptions": {
+                func: "{that}.postMessage",
+                args: [
+                    "create",
+                    [
+                        "berg.scheduler.postMessage",
+                        "{that}.options.remoteSchedulerOptions"
+                    ]
+                ]
+            },
 
-            onDestroy: [
-                {
-                    this: "{that}.worker",
-                    method: "terminate"
-                }
-            ]
+            "onDestroy.terminateWorker": {
+                this: "{that}.worker",
+                method: "terminate"
+            }
         }
     });
 

--- a/src/js/worker-setinterval-clock.js
+++ b/src/js/worker-setinterval-clock.js
@@ -53,9 +53,14 @@ var fluid = fluid || require("infusion"),
             "onStart.postStart": {
                 priority: "after:updateState",
                 func: "{that}.postMessage",
-                args: ["start", {
-                    freq: "{that}.freq"
-                }]
+                args: [
+                    "start",
+                    [
+                        {
+                            freq: "{that}.options.freq"
+                        }
+                    ]
+                ]
             },
 
             "onStop.postStop": {
@@ -64,8 +69,7 @@ var fluid = fluid || require("infusion"),
                 args: ["stop"]
             },
 
-            "onStop.terminateWorker": {
-                priority: "after:postStop",
+            "onDestroy.terminateWorker": {
                 this: "{that}.worker",
                 method: "terminate"
             }
@@ -110,14 +114,13 @@ var fluid = fluid || require("infusion"),
         self.addEventListener("message", function (e) {
             if (e.data.type === "start") {
                 berg.clock = berg.workerClock({
-                    freq: e.data.value
+                    freq: e.data.args[0].freq
                 });
                 berg.clock.start();
             } else if (e.data.type === "stop") {
                 if (berg.clock) {
                     berg.clock.stop();
                 }
-                self.close();
             }
         }, false);
     };


### PR DESCRIPTION
Fixes a bug in <code>workerSetInterval's</code> worker implementation where the posted options argument was not being read properly, causing the clock's frequency to never be set properly.

Adds a simple example/manual test for the <code>berg.clock.workerSetInterval</code>.